### PR TITLE
fix: Use here-doc for AppleScript execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the iTerm MCP Server will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Use here-doc syntax for AppleScript execution instead of single quotes
+- Remove unnecessary iTerm activation and 1-second wait delays
+- Improve handling of complex scripts with quotes and special characters
+- Add stderr logging for better debugging of AppleScript issues

--- a/index.js
+++ b/index.js
@@ -13,24 +13,18 @@ let terminalCounter = 0;
 // Helper function to execute AppleScript for iTerm
 async function executeITermScript(script) {
   const execPromise = promisify(exec);
-
-  // Simple launch script
-  const launchScript = `
-    tell application "iTerm"
-      activate
-    end tell
-  `;
-
+  
   try {
-    // First try to launch/activate iTerm
-    await execPromise(`osascript -e '${launchScript}'`);
-
-    // Wait a brief moment
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    // Now execute the actual script with iTerm instead of iTerm2
-    const modifiedScript = script.replace(/iTerm2/g, "iTerm");
-    const { stdout } = await execPromise(`osascript -e '${modifiedScript}'`);
+    // Use osascript with here-doc for better handling of complex scripts
+    // This avoids issues with quotes and special characters in AppleScript
+    const { stdout, stderr } = await execPromise(`osascript <<'EOF'
+${script}
+EOF`);
+    
+    if (stderr) {
+      console.error("iTerm AppleScript warning:", stderr);
+    }
+    
     return stdout.trim();
   } catch (error) {
     console.error("iTerm AppleScript error:", error);


### PR DESCRIPTION
- Replace single-quote execution with here-doc syntax
- Improves handling of complex scripts with quotes and special characters
- Add stderr logging for debugging
- Remove unnecessary iTerm activation and wait delays